### PR TITLE
Network performance and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Set-up instructions
 
 ```
-conda create -n eft_mva python=python=3.10.8
+conda create -n eft_mva python=3.10.8
 conda activate eft_mva
 
 # get pytorch https://pytorch.org/get-started/locally/
@@ -12,6 +12,7 @@ pip install tqdm
 pip install matplotlib
 pip install pyyaml
 pip install uproot awkward
+pip install torch
 
 ```
 

--- a/train.py
+++ b/train.py
@@ -80,9 +80,9 @@ def main():
 
 
     loss_train = []; loss_test=[]
-    for epoch in tqdm(range(args.epochs)):
+    for epoch in range(args.epochs):
         
-        for i,(sm_weight, bsm_weight, features) in enumerate(dataloader):
+        for i,(sm_weight, bsm_weight, features) in tqdm(enumerate(dataloader)):
             optimizer.zero_grad()
             loss = model.cost_from_batch(features, sm_weight, bsm_weight, args.device)
             loss.backward()

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+def net_eval(bins, sm_hist, bsm_hist, n_points=100, threshold=0.5):
+    
+    roc = np.array([])
+    
+    for i in range(n_points + 1):
+        thresholds = np.greater_equal(bins[:-1], i / n_points).astype(int)
+        fpr, tpr = get_rates(thresholds, sm_hist, bsm_hist)
+        roc = np.append(roc, [fpr, tpr])
+        
+    roc = roc.reshape(-1, 2)
+    auc = 0
+    
+    for i in range(n_points):
+        auc = auc + (roc[:,0][i]-roc[:,0][i+1])*(roc[:,1][i]+roc[:,1][i+1])/2
+        
+    bsm_cor = bsm_hist[np.greater_equal(bins[:-1], threshold).astype(bool)].sum()
+    sm_cor  = sm_hist[np.less_equal(bins[1:], 1 - threshold).astype(bool)].sum()
+    total   = bsm_hist.sum() + sm_hist.sum()
+    a = (bsm_cor + sm_cor) / total
+    
+    return roc, auc, a
+
+def get_rates(thresholds, sm_hist, bsm_hist):
+    tp  = bsm_hist[np.equal(thresholds, 1)]
+    fn  = bsm_hist[np.equal(thresholds, 0)]
+    tn  = sm_hist[np.equal(thresholds, 0)]
+    fp  = sm_hist[np.equal(thresholds, 1)]
+
+    tpr = tp.sum() / (tp.sum() + fn.sum())
+    fpr = fp.sum() / (fp.sum() + tn.sum())
+    
+    return fpr, tpr


### PR DESCRIPTION
The changes in the README file gets rid of a typo in the python version declaration and adds instructions to install pytorch. Within train.py, weighted histograms have been added as will as fixed bins. The histograms and bins are then sent to a new file utils/metrics.py. The file utils/metrics adds in two functions which find the ROC curve for network performance and calculates an approximate area under the ROC curve as well an accuracy score. Creation of plots has also been spaced out to every 200 epochs and includes epoch 0. 